### PR TITLE
Fix error in assert message for validateCurrentRecord

### DIFF
--- a/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
+++ b/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
@@ -35,9 +35,10 @@ public class TestUtilities extends AndroidTestCase {
             int idx = valueCursor.getColumnIndex(columnName);
             assertFalse("Column '" + columnName + "' not found. " + error, idx == -1);
             String expectedValue = entry.getValue().toString();
-            assertEquals("Value '" + entry.getValue().toString() +
+            String actualValue = valueCursor.getString(idx);
+            assertEquals("Value '" + actualValue +
                     "' did not match the expected value '" +
-                    expectedValue + "'. " + error, expectedValue, valueCursor.getString(idx));
+                    expectedValue + "'. " + error, expectedValue, actualValue);
         }
     }
 


### PR DESCRIPTION
The assert message in validateCurrentRecord currently shows "<expectedValue> does not match <expectedValue>" rather than "<actualValue> does not match <expectedValue>".

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/28)

<!-- Reviewable:end -->
