### PR TITLE
Added missing mContext reference

### DIFF
--- a/app/src/main/java/com/example/android/sunshine/app/ForecastAdapter.java
+++ b/app/src/main/java/com/example/android/sunshine/app/ForecastAdapter.java
@@ -22,7 +22,7 @@ public class ForecastAdapter extends CursorAdapter {
     /**
      * Prepare the weather high/lows for presentation.
      */
-    private String formatHighLows(double high, double low) {
+    private String formatHighLows(double high, double low, Context mContext) {
         boolean isMetric = Utility.isMetric(mContext);
         String highLowStr = Utility.formatTemperature(high, isMetric) + "/" + Utility.formatTemperature(low, isMetric);
         return highLowStr;
@@ -32,7 +32,7 @@ public class ForecastAdapter extends CursorAdapter {
         This is ported from FetchWeatherTask --- but now we go straight from the cursor to the
         string.
      */
-    private String convertCursorRowToUXFormat(Cursor cursor) {
+    private String convertCursorRowToUXFormat(Cursor cursor, Context context) {
         // get row indices for our cursor
         int idx_max_temp = cursor.getColumnIndex(WeatherContract.WeatherEntry.COLUMN_MAX_TEMP);
         int idx_min_temp = cursor.getColumnIndex(WeatherContract.WeatherEntry.COLUMN_MIN_TEMP);
@@ -41,7 +41,8 @@ public class ForecastAdapter extends CursorAdapter {
 
         String highAndLow = formatHighLows(
                 cursor.getDouble(idx_max_temp),
-                cursor.getDouble(idx_min_temp));
+                cursor.getDouble(idx_min_temp),
+                context);
 
         return Utility.formatDate(cursor.getLong(idx_date)) +
                 " - " + cursor.getString(idx_short_desc) +
@@ -67,6 +68,6 @@ public class ForecastAdapter extends CursorAdapter {
         // we'll keep the UI functional with a simple (and slow!) binding.
 
         TextView tv = (TextView)view;
-        tv.setText(convertCursorRowToUXFormat(cursor));
+        tv.setText(convertCursorRowToUXFormat(cursor, context));
     }
 }


### PR DESCRIPTION
Context is chain passed to 2 methods until it gets to the point of use(chained methods are private, thus safe for internal modification). Copy and paste error from FetchWeatherTask which had mContext as a class local variable.

This change will be required throughout all other branches that use it until less 5.XX

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/35)

<!-- Reviewable:end -->
