### PR TITLE
Update TestUtilities.java

### DIFF
--- a/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
+++ b/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
@@ -37,7 +37,7 @@ public class TestUtilities extends AndroidTestCase {
             int idx = valueCursor.getColumnIndex(columnName);
             assertFalse("Column '" + columnName + "' not found. " + error, idx == -1);
             String expectedValue = entry.getValue().toString();
-            assertEquals("Value '" + entry.getValue().toString() +
+            assertEquals("Value '" + valueCursor.getString(idx) +
                     "' did not match the expected value '" +
                     expectedValue + "'. " + error, expectedValue, valueCursor.getString(idx));
         }


### PR DESCRIPTION
The error string used in validateCurrentRecord is assembled using the expected value twice, so you end up with something like "Value:'foo' did not match the expected value 'foo'" if the actual value 'bar'.  The fix updates that string to "Value:'bar' did not match the expected value 'foo'", which is a much more useful message.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/40)

<!-- Reviewable:end -->
