### PR TITLE
Update fragment_detail_wide.xml

### DIFF
--- a/app/src/main/res/layout/fragment_detail_wide.xml
+++ b/app/src/main/res/layout/fragment_detail_wide.xml
@@ -74,7 +74,7 @@
                 android:layout_height="wrap_content" />
 
             <TextView
-                android:id="@+id/detail_forecast_textview"
+                android:id="@+id/detail_description_textview"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
         </LinearLayout>


### PR DESCRIPTION
Inconsistent naming between this file and fragment_detail.xml for the TextView positioned under the imageView for weather description. App crashes on tablet because TextView can´t be found.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/51)

<!-- Reviewable:end -->
