### PR TITLE
Avoid web api call on screen rotation / activity recreation

### DIFF
--- a/app/src/main/java/com/example/android/sunshine/app/MainActivity.java
+++ b/app/src/main/java/com/example/android/sunshine/app/MainActivity.java
@@ -28,7 +28,7 @@ public class MainActivity extends ActionBarActivity {
     private final String LOG_TAG = MainActivity.class.getSimpleName();
     private final String FORECASTFRAGMENT_TAG = "FFTAG";
 
-    private String mLocation;
+    private static String mLocation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
non static variable will be collected by garbage collector when screen rotates i.e. after onDestroy is called.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/61)

<!-- Reviewable:end -->
