### PR TITLE
Validate record: expected vs existing values

### DIFF
--- a/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
+++ b/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
@@ -37,7 +37,7 @@ public class TestUtilities extends AndroidTestCase {
             int idx = valueCursor.getColumnIndex(columnName);
             assertFalse("Column '" + columnName + "' not found. " + error, idx == -1);
             String expectedValue = entry.getValue().toString();
-            assertEquals("Value '" + entry.getValue().toString() +
+            assertEquals("Value '" + valueCursor.getString(idx) +
                     "' did not match the expected value '" +
                     expectedValue + "'. " + error, expectedValue, valueCursor.getString(idx));
         }


### PR DESCRIPTION
There is a small error in `sunshine/app/data/TestUtilities.java` when testing a record against the cursor values. The `assertEquals` will show the `expectedValue` twice. This is really minor problem.

Thanks for this inspiring app. I learned a lot.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/sunshine-version-2/64)

<!-- Reviewable:end -->
