### PR TITLE
Fix TestUtilities validateCurrentRecord error message

### DIFF
--- a/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
+++ b/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUtilities.java
@@ -37,7 +37,7 @@ public class TestUtilities extends AndroidTestCase {
             int idx = valueCursor.getColumnIndex(columnName);
             assertFalse("Column '" + columnName + "' not found. " + error, idx == -1);
             String expectedValue = entry.getValue().toString();
-            assertEquals("Value '" + entry.getValue().toString() +
+            assertEquals("Value '" + valueCursor.getString(idx) +
                     "' did not match the expected value '" +
                     expectedValue + "'. " + error, expectedValue, valueCursor.getString(idx));
         }


### PR DESCRIPTION
The original error message states to display 'cursor_value', but displays 'expected_value'; Now it should be fine.
However, all the course branches have to be rebased separately with this commit.
