### PR TITLE
Make sure ForecastFragment's host implements the Callback interface

### DIFF
--- a/app/src/main/java/com/example/android/sunshine/app/ForecastFragment.java
+++ b/app/src/main/java/com/example/android/sunshine/app/ForecastFragment.java
@@ -19,7 +19,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;

--- a/app/src/main/java/com/example/android/sunshine/app/ForecastFragment.java
+++ b/app/src/main/java/com/example/android/sunshine/app/ForecastFragment.java
@@ -15,9 +15,11 @@
  */
 package com.example.android.sunshine.app;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
@@ -81,6 +83,8 @@ public class ForecastFragment extends Fragment implements LoaderManager.LoaderCa
     static final int COL_WEATHER_CONDITION_ID = 6;
     static final int COL_COORD_LAT = 7;
     static final int COL_COORD_LONG = 8;
+
+    private Callback mCallBack;
 
     /**
      * A callback interface that all activities containing this fragment must
@@ -150,8 +154,8 @@ public class ForecastFragment extends Fragment implements LoaderManager.LoaderCa
                 Cursor cursor = (Cursor) adapterView.getItemAtPosition(position);
                 if (cursor != null) {
                     String locationSetting = Utility.getPreferredLocation(getActivity());
-                    ((Callback) getActivity())
-                            .onItemSelected(WeatherContract.WeatherEntry.buildWeatherLocationWithDate(
+
+                            mCallBack.onItemSelected(WeatherContract.WeatherEntry.buildWeatherLocationWithDate(
                                     locationSetting, cursor.getLong(COL_WEATHER_DATE)
                             ));
                 }
@@ -269,6 +273,25 @@ public class ForecastFragment extends Fragment implements LoaderManager.LoaderCa
         mUseTodayLayout = useTodayLayout;
         if (mForecastAdapter != null) {
             mForecastAdapter.setUseTodayLayout(mUseTodayLayout);
+
         }
     }
+
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+            // This makes sure that the host activity has implemented
+            // the callback interface. If not, it throws an exception
+            try {
+                mCallBack = (Callback) activity;
+            } catch (ClassCastException e) {
+                throw new ClassCastException(activity.toString()
+                        + " must implement " + getClass().toString() + " callback interface.");
+            }
+
+    }
+
 }


### PR DESCRIPTION
onAttach(Activity) is deprecated in Android M but since we're targeting API 21 in this repo, I override onAttach() to check if the ForecastFragment's host implements the Callback interface.
