### PR TITLE
Fix testUriMatcher assertEquals parameter's order

### DIFF
--- a/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUriMatcher.java
+++ b/app/src/androidTest/java/com/example/android/sunshine/app/data/TestUriMatcher.java
@@ -46,12 +46,12 @@ public class TestUriMatcher extends AndroidTestCase {
         UriMatcher testMatcher = WeatherProvider.buildUriMatcher();
 
         assertEquals("Error: The WEATHER URI was matched incorrectly.",
-                testMatcher.match(TEST_WEATHER_DIR), WeatherProvider.WEATHER);
+                WeatherProvider.WEATHER, testMatcher.match(TEST_WEATHER_DIR));
         assertEquals("Error: The WEATHER WITH LOCATION URI was matched incorrectly.",
-                testMatcher.match(TEST_WEATHER_WITH_LOCATION_DIR), WeatherProvider.WEATHER_WITH_LOCATION);
+                WeatherProvider.WEATHER_WITH_LOCATION, testMatcher.match(TEST_WEATHER_WITH_LOCATION_DIR));
         assertEquals("Error: The WEATHER WITH LOCATION AND DATE URI was matched incorrectly.",
-                testMatcher.match(TEST_WEATHER_WITH_LOCATION_AND_DATE_DIR), WeatherProvider.WEATHER_WITH_LOCATION_AND_DATE);
+                WeatherProvider.WEATHER_WITH_LOCATION_AND_DATE, testMatcher.match(TEST_WEATHER_WITH_LOCATION_AND_DATE_DIR));
         assertEquals("Error: The LOCATION URI was matched incorrectly.",
-                testMatcher.match(TEST_LOCATION_DIR), WeatherProvider.LOCATION);
+                WeatherProvider.LOCATION, testMatcher.match(TEST_LOCATION_DIR));
     }
 }


### PR DESCRIPTION
Apply fix for the assertion error log message for expected and current values.
